### PR TITLE
fix date-format issues on IE and Firefox

### DIFF
--- a/src/models/admin_/organization.py
+++ b/src/models/admin_/organization.py
@@ -48,7 +48,7 @@ class OrganizationPanelHandler(webapp2.RequestHandler):
         page_data = {}
         page_data['organization'] = org
         page_data['admins'] = self.admin_list(org)
-        page_data['elections'] = [elec.to_json() for elec in org.elections]
+        page_data['elections'] = [elec.to_json(True) for elec in org.elections]
         logging.info(page_data['elections'])
         logging.info(page_data)
         webapputils.render_page(self, PAGE_NAME, page_data)

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -47,14 +47,20 @@ class Election(db.Model):
     voted_count = db.IntegerProperty(required=True,
                                      default=0)
     description = db.TextProperty(required=False, default="")
-    def to_json(self):
+    def to_json(self, parseable_date=False):
+        # parseable_date means it can be parsed in JS with Date.parse()
+        times = {
+                'start': self.start.strftime('%a, %B %d, %Y, %I:%M %p') + ' UTC',
+                'end': self.end.strftime('%a, %B %d, %Y, %I:%M %p') + ' UTC'
+                } if parseable_date else {
+                'start': str(self.start),
+                'end': str(self.end)
+                }
         return {
             'id': str(self.key()),
             'name': self.name,
             'organization': self.organization.name,
-            'times': {
-                'start': str(self.start),
-                'end': str(self.end)},
+            'times': times,
             'result_computed': self.result_computed,
             'result_delay': self.result_delay,
             'universal': self.universal,

--- a/src/scripts/setup.py
+++ b/src/scripts/setup.py
@@ -20,6 +20,10 @@ def main():
                                 description='Not the best residential college.',
                                 website='http://baker.rice.edu')
     baker.put()
+    martel = models.Organization(name='Martel College',
+                                description='Best deck.',
+                                website='http://martel.rice.edu')
+    martel.put()
 
     print "Done."
     print "Creating admins..."
@@ -29,7 +33,8 @@ def main():
         ('dan1', 'dan1@rice.edu'),
         ('jcc7', 'jcc7@rice.edu'),
         ('jbb4', 'jbb4@rice.edu'),
-        ('cmp1', 'cmp1@rice.edu')
+        ('cmp1', 'cmp1@rice.edu'),
+        ('pe4', 'pe4@rice.edu')
     ]
 
     admins = []
@@ -45,6 +50,7 @@ def main():
 
     models.OrganizationAdmin(admin=admins[3], organization=mcmurtry).put()
     models.OrganizationAdmin(admin=admins[4], organization=baker).put()
+    models.OrganizationAdmin(admin=admins[5], organization=martel).put()
 
     print "Done."
 

--- a/src/views/vote.html
+++ b/src/views/vote.html
@@ -1,6 +1,5 @@
 <!-- Load JS / CSS
 ================================================== -->
-<script src="/static/js/shared/timezone.js"></script>
 <script src="/static/js/vote.js"></script>
 
 <section id="main" class='container-narrow'>


### PR DESCRIPTION
Add an option to elections' json dump that allows its output to be parsed with Date.parse on browsers other than Chrome. Also fix a double include that broke IE's date-format on voting page.
