### PR TITLE
Fix calls to missing render_template function

### DIFF
--- a/src/controllers/intern.py
+++ b/src/controllers/intern.py
@@ -19,7 +19,7 @@ class CommandCenterHandler(webapp2.RequestHandler):
     def get(self):
         voter = auth.get_voter(self)
         if voter.net_id not in COMMANDERS:
-            return webapputils.render_template('/templates/message', {
+            return webapputils.render_page(self, '/templates/message', {
                 'status': 'Not Authorized',
                 'msg': "You're not authorized to enter the command center"
             })
@@ -79,7 +79,7 @@ class JobsHandler(webapp2.RequestHandler):
     def get(self):
         voter = auth.get_voter(self)
         if voter.net_id not in COMMANDERS:
-            return webapputils.render_template('/templates/message', {
+            return webapputils.render_page(self, '/templates/message', {
                 'status': 'Not Authorized',
                 'msg': "You're not authorized to enter the command center"
             })


### PR DESCRIPTION
render_template does not exist, these are probably artifacts of
refactoring in the past. render_page is used instead.

Sorry about the PR barrage; I found this while working on the other things, but I'd rather not pollute the other requests.
