### PR TITLE
Replace dead shim urls

### DIFF
--- a/src/views/full_outage.html
+++ b/src/views/full_outage.html
@@ -22,7 +22,7 @@
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
     <![endif]-->
 
     <!-- Fav and touch icons -->

--- a/src/views/templates/page.html
+++ b/src/views/templates/page.html
@@ -21,7 +21,7 @@
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
     <![endif]-->
 
     <!-- Fav and touch icons -->


### PR DESCRIPTION
The urls over on `html5shim` on the google code project are dead. In the chance the shims are still needed, this PR adds active shim urls.